### PR TITLE
Support Elixir v1.10+ by replacing Keyword.keys

### DIFF
--- a/lib/ex_aws/auth.ex
+++ b/lib/ex_aws/auth.ex
@@ -151,7 +151,7 @@ defmodule ExAws.Auth do
     |> Enum.join("\n")
 
     signed_headers_list = headers
-    |> Keyword.keys
+    |> Enum.map(fn {k, _v} -> k end)
     |> Enum.join(";")
 
     payload = case body do


### PR DESCRIPTION
Keyword.keys now only allows atom-keys.
Replace this line with an Enum.map, which will collect all keys
regardless of type